### PR TITLE
OSUtils: removed duplicate and inconsistent os name sysprop retrieval

### DIFF
--- a/launching/src/main/java/org/jboss/tools/ssp/launching/util/OSUtils.java
+++ b/launching/src/main/java/org/jboss/tools/ssp/launching/util/OSUtils.java
@@ -9,12 +9,13 @@
 package org.jboss.tools.ssp.launching.util;
 
 public final class OSUtils {
+
 	private static String OS = System.getProperty("os.name").toLowerCase();
 
+	private OSUtils() {
+	}
+
 	public static String getOsName() {
-		if (OS == null) {
-			OS = System.getProperty("os.name");
-		}
 		return OS;
 	}
 


### PR DESCRIPTION
Signed-off-by: Andre Dietisheim <adietish@redhat.com>