### PR TITLE
Change non-void notifications to requests

### DIFF
--- a/api/src/main/java/org/jboss/tools/ssp/api/SSPServer.java
+++ b/api/src/main/java/org/jboss/tools/ssp/api/SSPServer.java
@@ -62,19 +62,19 @@ public interface SSPServer {
 	CompletableFuture<List<ServerBean>> findServerBeans(DiscoveryPath path);
 
 	/**
-	 * The `server/addDiscoveryPath` notification is sent by the client to add a new
+	 * The `server/addDiscoveryPath` request is sent by the client to add a new
 	 * path to search when discovering servers. These paths will be stored in a
 	 * model, to be queried or searched later by a client.
 	 */
-	@JsonNotification
+	@JsonRequest
 	CompletableFuture<Status> addDiscoveryPath(DiscoveryPath path);
 
 	/**
-	 * The `server/removeDiscoveryPath` notification is sent by the client to remove
+	 * The `server/removeDiscoveryPath` request is sent by the client to remove
 	 * a path from the model and prevent it from being searched by clients when
 	 * discovering servers in the future.
 	 */
-	@JsonNotification
+	@JsonRequest
 	CompletableFuture<Status> removeDiscoveryPath(DiscoveryPath path);
 	
 	
@@ -103,11 +103,11 @@ public interface SSPServer {
 	CompletableFuture<List<ServerType>> getServerTypes();
 
 	/**
-	 * The `server/deleteServer` notification is sent by the client to delete a
+	 * The `server/deleteServer` request is sent by the client to delete a
 	 * server from the model. This server will no longer be able to be started, shut
 	 * down, or interacted with in any fashion.
 	 */
-	@JsonNotification
+	@JsonRequest
 	CompletableFuture<Status> deleteServer(ServerHandle handle);
 
 	/**

--- a/schema/src/main/resources/schema/typescript/protocol.unified.d.ts
+++ b/schema/src/main/resources/schema/typescript/protocol.unified.d.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-// Generated using typescript-generator version 2.2.413 on 2018-07-18 18:30:02.
+// Generated using typescript-generator version 2.2.413 on 2018-07-19 10:57:12.
 
 export interface Attribute {
     type: string;

--- a/schema/src/main/resources/schemaMD/specification.md
+++ b/schema/src/main/resources/schemaMD/specification.md
@@ -277,7 +277,7 @@ This endpoint returns a list of the following schema as a return value:
 
 #### server/addDiscoveryPath
 
- The `server/addDiscoveryPath` notification is sent by the client to add a new path to search when discovering servers. These paths will be stored in a model, to be queried or searched later by a client. 
+ The `server/addDiscoveryPath` request is sent by the client to add a new path to search when discovering servers. These paths will be stored in a model, to be queried or searched later by a client. 
 
 This endpoint takes the following json schemas as parameters: 
 
@@ -329,7 +329,7 @@ This endpoint returns the following schema as a return value:
 
 #### server/removeDiscoveryPath
 
- The `server/removeDiscoveryPath` notification is sent by the client to remove a path from the model and prevent it from being searched by clients when discovering servers in the future. 
+ The `server/removeDiscoveryPath` request is sent by the client to remove a path from the model and prevent it from being searched by clients when discovering servers in the future. 
 
 This endpoint takes the following json schemas as parameters: 
 
@@ -450,7 +450,7 @@ This endpoint returns a list of the following schema as a return value:
 
 #### server/deleteServer
 
- The `server/deleteServer` notification is sent by the client to delete a server from the model. This server will no longer be able to be started, shut down, or interacted with in any fashion. 
+ The `server/deleteServer` request is sent by the client to delete a server from the model. This server will no longer be able to be started, shut down, or interacted with in any fashion. 
 
 This endpoint takes the following json schemas as parameters: 
 


### PR DESCRIPTION
As per https://www.jsonrpc.org/specification, "The Server MUST NOT reply to a Notification". Since some json notifications now return a status, changing them to request.